### PR TITLE
Feature/microservice status

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,4 +1,5 @@
 default:
+	docker network create api-backend || true
 	docker-compose build
 	docker-compose up
 

--- a/api/api_gateway/api_gateway/file_helper.py
+++ b/api/api_gateway/api_gateway/file_helper.py
@@ -1,0 +1,3 @@
+def file_get_contents(filename):
+    with open(filename) as f:
+        return f.read()

--- a/api/api_gateway/api_gateway/settings/common.py
+++ b/api/api_gateway/api_gateway/settings/common.py
@@ -103,6 +103,5 @@ STATIC_URL = '/static/'
 ## .env file
 ## Microservices path
 LOGIN = config('LOGIN_PATH', default='http://login-microservice:8000')
-ORDER = config('ORDER_PATH', default='http://order-microservice:8001')
-PRODUCTS = config('PRODUCTS_PATH', default='http://product-microservice:8002')
-DEBUG = config('DEBUG', default=True, cast=bool)
+ORDER = config('ORDER_PATH', default='http://order-microservice:8000')
+PRODUCTS = config('PRODUCTS_PATH', default='http://product-microservice:8000')

--- a/api/api_gateway/api_gateway/urls.py
+++ b/api/api_gateway/api_gateway/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from django.conf.urls import url, include
-from .version_helper import status
+from .views import status
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/api/api_gateway/api_gateway/urls.py
+++ b/api/api_gateway/api_gateway/urls.py
@@ -16,8 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from django.conf.urls import url, include
-from api_gateway import views
-from .views import status
+from .version_helper import status
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/api/api_gateway/api_gateway/urls.py
+++ b/api/api_gateway/api_gateway/urls.py
@@ -16,8 +16,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from django.conf.urls import url, include
+from api_gateway import views
+from .views import status
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', status),
     url(r'^', include('api.urls')),
 ]

--- a/api/api_gateway/api_gateway/version_helper.py
+++ b/api/api_gateway/api_gateway/version_helper.py
@@ -26,7 +26,7 @@ def status(request):
         }
     #Get order microservice version
     try:
-        response = requests.get(settings.PRODUCTS)
+        response = requests.get(settings.ORDER)
         order_json=response.json()
     except:
         order_json={

--- a/api/api_gateway/api_gateway/views.py
+++ b/api/api_gateway/api_gateway/views.py
@@ -2,6 +2,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 import requests
 from django.conf import settings
+from .file_helper import file_get_contents
 
 @api_view(['GET'])
 def status(request):
@@ -43,7 +44,3 @@ def status(request):
         order_json,
     ],
 })
-
-def file_get_contents(filename):
-    with open(filename) as f:
-        return f.read()

--- a/api/api_gateway/api_gateway/views.py
+++ b/api/api_gateway/api_gateway/views.py
@@ -1,8 +1,32 @@
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+import requests
 
 @api_view(['GET'])
 def status(request):
-    title = "message"
-    message = "Hello for today! See you tomorrow!"
-    return Response({title: message})
+    version=file_get_contents("../VERSION")
+    print (version)
+    return Response({
+    "name":"api-gateway",
+    "version":version,
+    "services":[
+        {
+            "name": "login-microservice",
+            "online": True,
+            "version": "0.1"
+        },
+        {
+            "name": "product-microservice",
+            "online": True,
+            "version": "0.1"
+        },
+        {
+            "name": "order-microservice",
+            "online": False
+        }
+    ],
+})
+
+def file_get_contents(filename):
+    with open(filename) as f:
+        return f.read()

--- a/api/api_gateway/api_gateway/views.py
+++ b/api/api_gateway/api_gateway/views.py
@@ -1,29 +1,46 @@
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 import requests
+from django.conf import settings
 
 @api_view(['GET'])
 def status(request):
-    version=file_get_contents("../VERSION")
-    print (version)
+    api_version=file_get_contents("../VERSION")
+    ##Get login microservice version
+    try:
+        response = requests.get(settings.LOGIN)
+        login_json=response.json()
+    except:
+        login_json={
+            "name": "login-microservice",
+            "online": False,
+        }
+    #Get product microservice version
+    try:
+        response = requests.get(settings.PRODUCTS)
+        product_json=response.json()
+    except:
+        product_json={
+            "name": "product-microservice",
+            "online": False,
+        }
+    #Get order microservice version
+    try:
+        response = requests.get(settings.PRODUCTS)
+        order_json=response.json()
+    except:
+        order_json={
+            "name": "order-microservice",
+            "online": False,
+        }
+
     return Response({
     "name":"api-gateway",
-    "version":version,
+    "version":api_version,
     "services":[
-        {
-            "name": "login-microservice",
-            "online": True,
-            "version": "0.1"
-        },
-        {
-            "name": "product-microservice",
-            "online": True,
-            "version": "0.1"
-        },
-        {
-            "name": "order-microservice",
-            "online": False
-        }
+        login_json,
+        product_json,
+        order_json,
     ],
 })
 

--- a/api/api_gateway/api_gateway/views.py
+++ b/api/api_gateway/api_gateway/views.py
@@ -1,0 +1,8 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+@api_view(['GET'])
+def status(request):
+    title = "message"
+    message = "Hello for today! See you tomorrow!"
+    return Response({title: message})

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,13 +1,21 @@
-version: '3.3'
+version: '3.5'
 
 services:
   web:
     build: .
+    container_name: "api-gateway"
     command: bash -c "sh run-django.sh"
     volumes:
       - .:/code
     ports:
       - 5000:8000
+    networks:
+      - api-backend
+
+networks:
+  api-backend:
+    external:
+      name: api-backend
 
 # ports - 5000:8000 
 # host:container


### PR DESCRIPTION
## Descrição
Mudança na URL raiz do micro serviço, agora passa se tornar uma API com método GET apenas, mostrando o status do micro serviço, seu nome e versão através de um json, também é mostrado o status de todos os outros micro serviços nesse json da seguinte forma:
![image](https://user-images.githubusercontent.com/32046134/46920244-b3fadc80-cfc1-11e8-8556-5d8d0942545e.png)

**Solução da issue**
fga-eps-mds/2018.2-iFood#190

Tarefas gerais realizadas
* Pegar dado de versão que esta no arquivo VERSION na raiz do repositório
* Microserviços devem expor sua versão na url base
* Caso microserviço esteja offline API Gateway não precisa mostrar versão
* API Gateway mostrar dados de todos os serviços na base da url

## Executando
Para a execução é necessário que os referentes pull requests sejam aceitos antes desse.
* fga-eps-mds/2018.2-FGAPP-login#17
* fga-eps-mds/2018.2-FGAPP-produto#20
* fga-eps-mds/2018.2-FGAPP-vendas#12

Caso se queira rodar independente dos pull requests as branchs usadas para os 3 micro serviços tem o nome de: feature/microservice-status 